### PR TITLE
Application Metadata Added To Tuples

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,9 +36,22 @@
         <curator.version>2.5.0</curator.version>
         <storm.version>0.9.3</storm.version>
         <junit.version>4.11</junit.version>
+
+        <!--
+        - Storm 0.9.3 Requires JDK 1.6 or higher, so we're safe to set this version for our library.
+        - See: https://github.com/apache/storm/blob/v0.9.3/pom.xml#L618
+        -->
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <maven.compiler.source>1.6</maven.compiler.source>
     </properties>
     <build>
         <plugins>
+            <plugin>
+                <!-- Latest version of compiler plugin -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>

--- a/src/main/java/com/microsoft/eventhubs/spout/EventDataScheme.java
+++ b/src/main/java/com/microsoft/eventhubs/spout/EventDataScheme.java
@@ -19,10 +19,14 @@ package com.microsoft.eventhubs.spout;
 
 import backtype.storm.tuple.Fields;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+
 import org.apache.qpid.amqp_1_0.client.Message;
 import org.apache.qpid.amqp_1_0.type.Section;
 import org.apache.qpid.amqp_1_0.type.messaging.AmqpValue;
+import org.apache.qpid.amqp_1_0.type.messaging.ApplicationProperties;
 import org.apache.qpid.amqp_1_0.type.messaging.Data;
 
 public class EventDataScheme implements IEventDataScheme {
@@ -31,25 +35,34 @@ public class EventDataScheme implements IEventDataScheme {
 
   @Override
   public List<Object> deserialize(Message message) {
-    List<Object> fieldContents = new ArrayList<Object>();
+    final List<Object> fieldContents = new ArrayList<Object>();
+
+    /**
+     * Default values.
+     */
+    Map metaDataMap = new HashMap();
+    String messageData = "";
 
     for (Section section : message.getPayload()) {
       if (section instanceof Data) {
         Data data = (Data) section;
-        fieldContents.add(new String(data.getValue().getArray()));
-        return fieldContents;
+        messageData = new String(data.getValue().getArray());
       } else if (section instanceof AmqpValue) {
         AmqpValue amqpValue = (AmqpValue) section;
-        fieldContents.add(amqpValue.getValue().toString());
-        return fieldContents;
+        messageData = amqpValue.getValue().toString();
+      } else if(section instanceof ApplicationProperties) {
+        final ApplicationProperties applicationProperties = (ApplicationProperties) section;
+        metaDataMap = applicationProperties.getValue();
       }
     }
 
-    return null;
+    fieldContents.add(messageData);
+    fieldContents.add(metaDataMap);
+    return fieldContents;
   }
 
   @Override
   public Fields getOutputFields() {
-    return new Fields(FieldConstants.Message);
+    return new Fields(FieldConstants.Message, FieldConstants.META_DATA);
   }
 }

--- a/src/main/java/com/microsoft/eventhubs/spout/FieldConstants.java
+++ b/src/main/java/com/microsoft/eventhubs/spout/FieldConstants.java
@@ -22,4 +22,5 @@ public class FieldConstants {
   public static final String PartitionKey = "partitionKey";
   public static final String Offset = "offset";
   public static final String Message = "message";
+  public static final String META_DATA = "metadata";
 }

--- a/src/main/java/com/microsoft/eventhubs/spout/IEventDataScheme.java
+++ b/src/main/java/com/microsoft/eventhubs/spout/IEventDataScheme.java
@@ -24,7 +24,20 @@ import org.apache.qpid.amqp_1_0.client.Message;
 
 public interface IEventDataScheme extends Serializable {
 
+  /**
+   * Deserialize an AMQP Message into a Tuple.
+   *
+   * @see #getOutputFields() for the list of fields the tuple will contain.
+   *
+   * @param message The Message to Deserialize.
+   * @return A tuple containing the deserialized fields of the message.
+   */
   List<Object> deserialize(Message message);
 
+  /**
+   * Retrieve the Fields that are present on tuples created by this object.
+   *
+   * @return The Fields that are present on tuples created by this object.
+   */
   Fields getOutputFields();
 }


### PR DESCRIPTION
AMQP supports the ability to add Application Properties to AMQP Messages.  These are useful to downstream bolts.  The current implementation only passes the data portion of the Message down to bolts.

This change adds the extraction of the Application Properties and adds them as an additional field to the tuple generated by the Event Spout.

This PR also contains some minor pom cleanup - setting the JDK targets to 1.6 (instead of relying on the default of 1.5) and ensuring the latest version of the Maven Compiler Plugin.
