### PR TITLE
Binary data support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+#
+# IntelliJ Files
+#
+.idea/
+*.iml
+
+#
+# Maven Files
+#
+target/

--- a/src/main/java/com/microsoft/eventhubs/spout/BinaryEventDataScheme.java
+++ b/src/main/java/com/microsoft/eventhubs/spout/BinaryEventDataScheme.java
@@ -1,0 +1,51 @@
+package com.microsoft.eventhubs.spout;
+
+import backtype.storm.tuple.Fields;
+import org.apache.qpid.amqp_1_0.client.Message;
+import org.apache.qpid.amqp_1_0.type.Section;
+import org.apache.qpid.amqp_1_0.type.messaging.ApplicationProperties;
+import org.apache.qpid.amqp_1_0.type.messaging.Data;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * An Event Data Scheme which deserializes the message payloads into the raw bytes.
+ *
+ * Contrast this to the default EventDataScheme which deserializes into String.  The assumption that these payloads
+ * are Strings isn't always true and so this implementation allows for a more robust use case.
+ */
+public class BinaryEventDataScheme implements IEventDataScheme {
+
+    @Override
+    public List<Object> deserialize(Message message) {
+        final List<Object> fieldContents = new ArrayList<Object>();
+
+        /**
+         * Default values.
+         */
+        Map metaDataMap = new HashMap();
+        byte[] messageData = new byte[0];
+
+        for (Section section : message.getPayload()) {
+            if (section instanceof Data) {
+                Data data = (Data) section;
+                messageData = data.getValue().getArray();
+            } else if(section instanceof ApplicationProperties) {
+                final ApplicationProperties applicationProperties = (ApplicationProperties) section;
+                metaDataMap = applicationProperties.getValue();
+            }
+        }
+
+        fieldContents.add(messageData);
+        fieldContents.add(metaDataMap);
+        return fieldContents;
+    }
+
+    @Override
+    public Fields getOutputFields() {
+        return new Fields(FieldConstants.Message, FieldConstants.META_DATA);
+    }
+}

--- a/src/main/java/com/microsoft/eventhubs/spout/EventDataScheme.java
+++ b/src/main/java/com/microsoft/eventhubs/spout/EventDataScheme.java
@@ -29,6 +29,13 @@ import org.apache.qpid.amqp_1_0.type.messaging.AmqpValue;
 import org.apache.qpid.amqp_1_0.type.messaging.ApplicationProperties;
 import org.apache.qpid.amqp_1_0.type.messaging.Data;
 
+/**
+ * This implementation converts the Message payload into Strings and passes them on.
+ *
+ * This makes the assumption that the payload is String data and not some other type of binary format (ie. compressed data for example).
+ *
+ * If you want to pass the raw bytes to your Bolts, use the {@link BinaryEventDataScheme} class.
+ */
 public class EventDataScheme implements IEventDataScheme {
 
   private static final long serialVersionUID = 1L;

--- a/src/test/java/com/microsoft/eventhubs/spout/BinaryEventDataSchemeTest.java
+++ b/src/test/java/com/microsoft/eventhubs/spout/BinaryEventDataSchemeTest.java
@@ -1,0 +1,73 @@
+package com.microsoft.eventhubs.spout;
+
+import org.apache.qpid.amqp_1_0.client.Message;
+import org.apache.qpid.amqp_1_0.type.Binary;
+import org.apache.qpid.amqp_1_0.type.Section;
+import org.apache.qpid.amqp_1_0.type.messaging.ApplicationProperties;
+import org.apache.qpid.amqp_1_0.type.messaging.Data;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class BinaryEventDataSchemeTest {
+
+    private static final String TEST_KEY = "TEST_KEY";
+    private static final String TEST_VALUE = "TEST_VALUE";
+    private static final String TEST_MESSAGE_DATA = "Hello world";
+    private BinaryEventDataScheme scheme;
+
+    @Before
+    public void setUp() throws Exception {
+        scheme = new BinaryEventDataScheme();
+    }
+
+    @Test
+    public void testDeserialize() {
+
+        final Message message = buildMessage();
+
+        final List<Object> tuple = scheme.deserialize(message);
+
+        assertEquals("Tuple field count does not match declared field count", scheme.getOutputFields().size(), tuple.size());
+
+        final byte[] dataResult = (byte[]) tuple.get(0);
+        assertEquals(TEST_MESSAGE_DATA, new String(dataResult));
+
+        final Map metaDataResult = (Map) tuple.get(1);
+        assertTrue(metaDataResult.containsKey(TEST_KEY));
+        assertEquals(TEST_VALUE, metaDataResult.get(TEST_KEY));
+    }
+
+    @Test
+    public void testDeserializeDefaults() {
+        final List<Object> tuple = scheme.deserialize(new Message());
+
+        assertEquals("Tuple field count does not match declared field count", scheme.getOutputFields().size(), tuple.size());
+
+        final byte[] dataResult = (byte[]) tuple.get(0);
+        assertEquals("", new String(dataResult));
+
+        final Map metaDataResult = (Map) tuple.get(1);
+        assertTrue(metaDataResult.isEmpty());
+    }
+
+    private Message buildMessage() {
+        final Data data = new Data(new Binary(TEST_MESSAGE_DATA.getBytes()));
+        final Map<String, String> metaDataMap = new HashMap<String, String>();
+        metaDataMap.put(TEST_KEY, TEST_VALUE);
+        final ApplicationProperties metaData = new ApplicationProperties(metaDataMap);
+
+        List<Section> sections = new ArrayList<Section>();
+        sections.add(data);
+        sections.add(metaData);
+
+        return new Message(sections);
+    }
+}


### PR DESCRIPTION
The current implementation uses a default EventDataScheme which assumes that the payloads of all messages are Strings.  This assumption doesn't always hold and so this PR introduces an implementation of EventDataScheme that passes the raw bytes from the spout to the bolts and thus lets the bolts make the determination on how to process these bytes.
